### PR TITLE
F #58 feat: enhance Home component with profile image and translation…

### DIFF
--- a/portfolio-resources/design/pencil-new.pen
+++ b/portfolio-resources/design/pencil-new.pen
@@ -154,6 +154,7 @@
                   "id": "6XHKw",
                   "name": "Frame 5",
                   "width": "fill_container",
+                  "height": 58,
                   "gap": 16,
                   "alignItems": "center",
                   "children": [

--- a/portfolio-ui/src/components/Home/Home.jsx
+++ b/portfolio-ui/src/components/Home/Home.jsx
@@ -1,3 +1,36 @@
+import profile from "../../assets/images/profile.png";
+import { useTranslation } from "react-i18next";
+import { NavLink } from "react-router-dom";
+
 export default function Home() {
-  return <div>Home</div>;
+  const { t: translate, i18n: i18nInstance } = useTranslation();
+
+  return (
+    <div className="flex flex-col lg:flex-row lg:justify-center lg:h-[calc(100vh-7.5rem)] items-center w-full h-full">
+      <div className="w-full h-1/2 flex-1 p-2 mt-12 flex items-center justify-center">
+        <img
+          src={profile}
+          alt={translate("nav.home")}
+          className="w-full h-full sm:h-96 object-contain"
+        />
+      </div>
+      <div className="flex flex-col w-full flex-1 justify-start items-center lg:items-start gap-2 px-5 mt-4">
+        <div className="font-bold text-[3rem] md:text-[5rem] sm:text-[3rem]">
+          <span className="mr-3">{translate("home.greeting")}</span>
+          <span className="text-(--accent-red)">{translate("home.name")}</span>
+        </div>
+        <div className="text-[1rem] sm:text-[1.5rem] md:text-[2rem] text-center lg:text-left">
+          <span>{translate("home.description")}</span>
+        </div>
+        <div className="mt-2">
+          <NavLink
+            to="/contact-me"
+            className="px-6 py-2 border border-(--accent-red) bg-brand-dark text-(--accent-red) rounded hover:opacity-90 inline-block text-[1.5rem]"
+          >
+            {translate("home.contact")}
+          </NavLink>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/portfolio-ui/src/components/Template/Template.jsx
+++ b/portfolio-ui/src/components/Template/Template.jsx
@@ -97,7 +97,7 @@ export default function Template() {
       </header>
 
       <main className="flex-1 overflow-auto bg-(--brand-dark) text-white">
-        <div className="w-full max-w-5xl mx-auto px-4">
+        <div className="w-full max-w-5xl mx-auto px-4 ">
           <Outlet />
         </div>
       </main>

--- a/portfolio-ui/src/locales/en/translation.json
+++ b/portfolio-ui/src/locales/en/translation.json
@@ -11,5 +11,11 @@
   },
   "lang": {
     "change": "Change language. Current: {{lang}}"
+  },
+  "home": {
+    "greeting": "I'm  ",
+    "name": "Moroni",
+    "description": "Developer with vision... virtual and professional",
+    "contact": "CONTACT ME"
   }
 }

--- a/portfolio-ui/src/locales/es/translation.json
+++ b/portfolio-ui/src/locales/es/translation.json
@@ -11,5 +11,11 @@
   },
   "lang": {
     "change": "Cambiar idioma. Idioma actual: {{lang}}"
+  },
+  "home": {
+    "greeting": "Soy",
+    "name": "Moroni",
+    "description": "Desarrollador con visión... virtual y profesional",
+    "contact": "CONTÁCTAME"
   }
 }


### PR DESCRIPTION
This pull request updates the Home page to introduce a new profile section with localized content and improved layout. The main changes include implementing a responsive Home component that displays a profile image, greeting, description, and a contact button, all with support for English and Spanish translations.

**Home page redesign and localization:**

* Replaced the placeholder Home component with a responsive layout featuring a profile image, localized greeting, description, and a contact button using `react-i18next` for translations and `react-router-dom` for navigation. (`portfolio-ui/src/components/Home/Home.jsx`)
* Added English translations for the Home page, including greeting, name, description, and contact button text. (`portfolio-ui/src/locales/en/translation.json`)
* Added Spanish translations for the Home page, including greeting, name, description, and contact button text. (`portfolio-ui/src/locales/es/translation.json`)

**Design adjustment:**

* Set a fixed height for `Frame 5` in the design resource to improve layout consistency. (`portfolio-resources/design/pencil-new.pen`)