### PR TITLE
F #60 feat: enhance AboutMe component with dynamic format display and…

### DIFF
--- a/portfolio-ui/src/components/AboutMe/AboutMe.jsx
+++ b/portfolio-ui/src/components/AboutMe/AboutMe.jsx
@@ -1,3 +1,33 @@
+import { useEffect, useState } from "react";
+import OutputFormats from "./OutputFormats";
+import profileImg from "../../assets/images/profile.png";
+
 export default function AboutMe() {
-  return <div>About Me</div>;
+  const formats = ["java", "python", "html"];
+  const [format, setFormat] = useState("java");
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setFormat((prev) => {
+        const idx = formats.indexOf(prev);
+        return formats[(idx + 1) % formats.length];
+      });
+    }, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-4 lg:h-[calc(100vh-7.5rem)] justify-center items-center ">
+      <div className="flex items-center justify-center w-full h-[50%]">
+        <img
+          src={profileImg}
+          alt="Profile"
+          className=" h-[50%] md:h-110 lg:h-full rounded-full object-cover"
+        />
+      </div>
+      <div className="flex-none">
+        <OutputFormats format={format} />
+      </div>
+    </div>
+  );
 }

--- a/portfolio-ui/src/components/AboutMe/OutputFormats.jsx
+++ b/portfolio-ui/src/components/AboutMe/OutputFormats.jsx
@@ -1,0 +1,61 @@
+import { Trans } from "react-i18next";
+
+export default function OutputFormats({ format = "html" }) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col md:flex-row text-[0.75rem] md:text-[0.95rem] lg:text-[1rem] font-normal justify-center">
+        <div className="w-full md:w-[20%] flex justify-start md:justify-end ">
+          {format === "java" ? (
+            <span className="me-1 tracking-[1.08px]">
+              System.<span className="text-(--accent-red)">out</span>.println
+              <span className="text-(--accent-red)">("</span>
+            </span>
+          ) : format === "python" ? (
+            <span className="me-1 tracking-[1.08px]">
+              <span className="">print</span>
+              <span className="text-(--accent-red)">('</span>
+            </span>
+          ) : format === "html" ? (
+            <span className="me-1 tracking-[1.08px]">
+              <span className="text-(--accent-red)">{"<"}</span>
+              <span className="">span</span>
+              <span className="text-(--accent-red)">{">"}</span>
+            </span>
+          ) : null}
+        </div>
+        <div className="flex md:justify-center text-white tracking-[1.08px] w-fulls md:w-[40%] lg:w-[60%] shrink-0">
+          <span className="">
+            <Trans
+              i18nKey="aboutme.description"
+              components={{
+                accent: <strong className="font-bold text-(--accent-red)" />,
+                strong: <strong className="font-bold" />,
+                br: <br />,
+              }}
+            />
+          </span>
+        </div>
+        <div className="flex justify-items-end items-end w-full md:w-[20%]">
+          <span className=" justify-self-end tracking-[1.08px] ">
+            {format === "java" ? (
+              <>
+                <span className=" text-(--accent-red)">{'")'}</span>
+                <span>;</span>
+              </>
+            ) : format === "python" ? (
+              <>
+                <span className=" text-(--accent-red)">{'")'}</span>
+              </>
+            ) : format === "html" ? (
+              <>
+                <span className=" text-(--accent-red)">{"</"}</span>
+                <span className="">span</span>
+                <span className=" text-(--accent-red)">{">"}</span>
+              </>
+            ) : null}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/portfolio-ui/src/locales/en/translation.json
+++ b/portfolio-ui/src/locales/en/translation.json
@@ -18,4 +18,8 @@
     "description": "Developer with vision... virtual and professional",
     "contact": "CONTACT ME"
   }
+  ,
+  "aboutme": {
+    "description": "I am a <accent>Developer</accent> with a passion for technology and a clear focus on creating solutions that make a real impact.<br/><br/>I have worked on national and international projects using tools such as <strong>Java</strong>, <strong>Python</strong>, <strong>React</strong>, and <strong>Docker</strong>.<br/><br/>Today I combine development with <strong>Data Science</strong> and <strong>Machine Learning</strong>, building systems that not only work but also learn and evolve. I am defined by clear communication, leadership, and a strategic vision that goes beyond code."
+  }
 }

--- a/portfolio-ui/src/locales/es/translation.json
+++ b/portfolio-ui/src/locales/es/translation.json
@@ -18,4 +18,8 @@
     "description": "Desarrollador con visión... virtual y profesional",
     "contact": "CONTÁCTAME"
   }
+  ,
+  "aboutme": {
+     "description": "Soy un <accent>Desarrollador</accent> con pasión por la tecnología y un enfoque claro en crear soluciones que generen un impacto real.<br/><br/>He trabajado en proyectos nacionales e internacionales usando herramientas como <strong>Java</strong>, <strong>Python</strong>, <strong>React</strong> y <strong>Docker</strong>.<br/><br/>Hoy combino el desarrollo con <strong>Data Science</strong> y <strong>Machine Learning</strong>, construyendo sistemas que no solo funcionan sino que también aprenden y evolucionan. Me defino por la comunicación clara, el liderazgo y una visión estratégica que va más allá del código."
+  }
 }


### PR DESCRIPTION
This pull request introduces a new, interactive "About Me" section to the portfolio UI, featuring animated code-style output in multiple programming languages and localized descriptions. The main changes include implementing the animated format switcher, adding the corresponding presentational component, and updating translation files with rich, localized content.

**New "About Me" section and animated output:**

* Added a new `AboutMe` component that displays a profile image and cycles through code-style output formats (`java`, `python`, `html`) every two seconds, enhancing visual engagement. (`portfolio-ui/src/components/AboutMe/AboutMe.jsx`)
* Created an `OutputFormats` component that renders the "About Me" description wrapped in language-appropriate code snippets, using `react-i18next` to support translation and rich formatting. (`portfolio-ui/src/components/AboutMe/OutputFormats.jsx`)

**Localization and content:**

* Updated English translation file with a detailed, formatted "About Me" description, supporting accent and strong tags as well as line breaks. (`portfolio-ui/src/locales/en/translation.json`)
* Added the equivalent Spanish translation for the "About Me" section, ensuring bilingual support with matching formatting. (`portfolio-ui/src/locales/es/translation.json`)… profile image; add translations for About Me section